### PR TITLE
Add countdown prompt for incomplete quiz access

### DIFF
--- a/src/webpages/Recommendpage/Recommend.jsx
+++ b/src/webpages/Recommendpage/Recommend.jsx
@@ -53,16 +53,22 @@ const RecommendedProfessorsPage = () => {
                 const data = await response.json();
                 console.log('Received professor data:', data);
 
-                if (!data || !data.recommended_professors) {
-                    console.error('Error: professors data is missing');
-                    return;
+                if (data.message === 'User has not taken the quiz yet.') {
+                    setQuizPromptVisible(true);
+                    const interval = setInterval(() => {
+                        setCountdown(prevCountdown => prevCountdown - 1);
+                    }, 1000);
+                    setTimeout(() => {
+                        clearInterval(interval);
+                        navigate('/quizpage');
+                    }, 3000);
                 }
 
                 data.recommended_professors.forEach(professor => {
                     professor.department = professor.department.split(';').map(dept => removeDepartmentPrefix(dept.trim())).join('; ');
                 });
 
-                if (data.message === 'Quiz result not found for the given user ID.') {
+                if (data.message === 'User has not taken the quiz yet.') {
                     setQuizPromptVisible(true);
                     const interval = setInterval(() => {
                         setCountdown(prevCountdown => prevCountdown - 1);
@@ -76,7 +82,6 @@ const RecommendedProfessorsPage = () => {
                 }
                 setIsLoading(false);
             } catch (error) {
-                console.error('Error fetching data:', error);
                 setIsLoading(false);
             }
         };


### PR DESCRIPTION
Added logic to display a countdown page when users who haven't completed the quiz attempt to access the Recommended Professors page. This ensures a better user experience by providing a prompt before redirecting to the quiz page. The countdown page is shown for 3 seconds before automatically redirecting to the quiz page. Additionally, updated the useEffect hook to set quizPromptVisible to true when receiving an error message indicating that the user hasn't taken the quiz yet.